### PR TITLE
Decrement the reference count on the invocation object in _method_callback

### DIFF
--- a/dasbus/server/handler.py
+++ b/dasbus/server/handler.py
@@ -470,6 +470,8 @@ class ServerObjectHandler(AbstractServerObjectHandler):
                 method_name,
                 error
             )
+        finally:
+            invocation._unref()
 
     def _get_additional_arguments(self, invocation, interface_name,
                                   method_name, parameters):


### PR DESCRIPTION
The caller is responsible for doing this according to:
https://docs.gtk.org/gio/callback.DBusInterfaceMethodCallFunc.html

this should fix #80 